### PR TITLE
Add Kerbalism radiation configurations to all bodies in the Debdeb system.

### DIFF
--- a/GameData/PromisedWorlds/_Systems/Debdeb/Misc/Kerbalism/Kerbalism Radiation.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Misc/Kerbalism/Kerbalism Radiation.cfg
@@ -2,6 +2,27 @@
 
 RadiationBody:NEEDS[PromisedWorlds]
 {
+        name = Axod
+        radiation_model = ionosphere
+        radiation_pause = -0.005
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Bis
+        radiation_model = surface
+        radiation_surface = 0.010
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Charr
+        radiation_model = surface
+        radiation_surface = 0.020
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
         name = Debdeb
         radiation_model = heliopause
         radiation_pause = -0.025
@@ -11,9 +32,39 @@ RadiationBody:NEEDS[PromisedWorlds]
 
 RadiationBody:NEEDS[PromisedWorlds]
 {
-        name = Ovin
+        name = Diros
+        radiation_model = surface
+        radiation_surface = 0.020
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Donk
+        radiation_model = surface
+        radiation_surface = 0.010
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Dorau
+        radiation_model = earth
+        radiation_inner = 5.0
+        radiation_outer = 0.5
+        radiation_pause = -0.05
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Glumo
         radiation_model = ionosphere
-        radiation_pause = -0.005
+        radiation_pause = -0.015
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Gup
+        radiation_model = surface
+        radiation_surface = 0.010
 }
 
 RadiationBody:NEEDS[PromisedWorlds]
@@ -27,14 +78,81 @@ RadiationBody:NEEDS[PromisedWorlds]
 
 RadiationBody:NEEDS[PromisedWorlds]
 {
-        name = Gup
+        name = Jut
         radiation_model = surface
         radiation_surface = 0.010
 }
 
 RadiationBody:NEEDS[PromisedWorlds]
 {
-        name = Donk
+        name = Kleid
+        radiation_model = surface
+        radiation_surface = 0.010
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Lapat
+        radiation_model = earth
+        radiation_inner = 4.0
+        radiation_outer = 0.4
+        radiation_pause = -0.05
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Merbel
+        radiation_model = earth
+        radiation_inner = 12.0
+        radiation_outer = 1.5
+        radiation_pause = -0.05
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Mesma
+        radiation_model = surface
+        radiation_surface = 0.008
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Noj
+        radiation_model = surface
+        radiation_surface = 0.010
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Omasa
+        radiation_model = surface
+        radiation_surface = 0.008
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Ovin
+        radiation_model = ionosphere
+        radiation_pause = -0.005
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Rosh
+        radiation_model = surface
+        radiation_surface = 0.010
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Shana
+        radiation_model = surface
+        radiation_surface = 0.010
+}
+
+RadiationBody:NEEDS[PromisedWorlds]
+{
+        name = Umod
         radiation_model = surface
         radiation_surface = 0.010
 }

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Misc/ScienceDefs/ScienceDefs.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Misc/ScienceDefs/ScienceDefs.cfg
@@ -324,19 +324,7 @@
 	}
 }
 
-@EXPERIMENT_DEFINITION:HAS[#id[evaReport]]
-{
-    @RESULTS
-    {
-        // ----- DEBDEB -----
 
-        DebdebSrfLanded = You are walking on the surface of a star. Splendid.
-        DebdebFlyingLow = Your suit is somehow enduring millions of Kelvins of temperature. How are you even alive?
-        DebdebFlyingHigh = You look at the massive star below you, almost completely covering your view.
-        DebdebInSpaceLow = PLEASE LET ME BACK IN I'M GOING TO DIE HERE
-        DebdebInSpaceHigh = Debdeb shines brightly outside your suit. It's getting a little hot in here.
-    }
-}
 
 
 

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Misc/ScienceDefs/ScienceDefs.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Misc/ScienceDefs/ScienceDefs.cfg
@@ -324,7 +324,19 @@
 	}
 }
 
+@EXPERIMENT_DEFINITION:HAS[#id[evaReport]]
+{
+    @RESULTS
+    {
+        // ----- DEBDEB -----
 
+        DebdebSrfLanded = You are walking on the surface of a star. Splendid.
+        DebdebFlyingLow = Your suit is somehow enduring millions of Kelvins of temperature. How are you even alive?
+        DebdebFlyingHigh = You look at the massive star below you, almost completely covering your view.
+        DebdebInSpaceLow = PLEASE LET ME BACK IN I'M GOING TO DIE HERE
+        DebdebInSpaceHigh = Debdeb shines brightly outside your suit. It's getting a little hot in here.
+    }
+}
 
 
 


### PR DESCRIPTION
This pull request also re-arranges the bodies in the radiation config to be in alphabetical order.

Note: Do not pay attention to the "Debdeb science" commit, as it was reverted and I have no idea why it still appears. The only file changed is the Kerbalism radiation config.