### PR TITLE
Add support for DresKillerBase

### DIFF
--- a/GameData/PromisedWorlds/_Systems/Debdeb/Misc/DresKillerBase.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Misc/DresKillerBase.cfg
@@ -1,0 +1,10 @@
+﻿@Kopernicus:NEEDS[DKB]
+{
+    @Body[KevbasAnomalyA]
+  	{
+    		@Orbit
+    		{
+    		    %referenceBody = DresKillerBase
+    		}
+  	}
+}


### PR DESCRIPTION
This pull request adds support for DresKillerBase by fixing the orbit of the wormhole in the Kerbol system (Wormhole A)